### PR TITLE
Fixes module import

### DIFF
--- a/content_disposition/__init__.py
+++ b/content_disposition/__init__.py
@@ -1,0 +1,1 @@
+from .content_disposition import *

--- a/content_disposition/content_disposition.py
+++ b/content_disposition/content_disposition.py
@@ -2,6 +2,10 @@
 import unicodedata
 from urllib.parse import quote
 
+__all__ = [
+    "rfc5987_content_disposition",
+]
+
 
 def rfc5987_content_disposition(file_name, disposition_type="inline"):
     """
@@ -11,9 +15,7 @@ def rfc5987_content_disposition(file_name, disposition_type="inline"):
     :param disposition_type: str
     :return:
     """
-    ascii_name = (
-        unicodedata.normalize("NFKD", file_name).encode("ascii", "ignore").decode()
-    )
+    ascii_name = unicodedata.normalize("NFKD", file_name).encode("ascii", "ignore").decode()
     header = '{}; filename="{}"'.format(disposition_type, ascii_name)
     if ascii_name != file_name:
         quoted_name = quote(file_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 120
+target-version = ['py39']
+exclude = '''
+/(
+    manage.py
+  | migrations
+)/
+'''

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -2,7 +2,7 @@ from django.http import FileResponse
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
-from content_disposition.content_disposition import rfc5987_content_disposition
+from content_disposition import rfc5987_content_disposition
 
 from .models import Photo
 from .serializers import PhotoSerializer
@@ -30,8 +30,6 @@ class PhotoViewSet(viewsets.ModelViewSet):
             open(instance.file.path, "rb").read(),
             content_type=instance.mime,
         )
-        response["Content-Disposition"] = rfc5987_content_disposition(
-            instance.file.name
-        )
+        response["Content-Disposition"] = rfc5987_content_disposition(instance.file.name)
 
         return response


### PR DESCRIPTION
This is a change that allows to use the module as specified in the readme: `from content_disposition import rfc5987_content_disposition` instead of `from content_disposition.content_disposition import rfc5987_content_disposition`